### PR TITLE
Add runnable backend container and weather provider stubs

### DIFF
--- a/backend/core/providers/openmeteo.py
+++ b/backend/core/providers/openmeteo.py
@@ -1,6 +1,8 @@
 """Open-Meteo provider stub."""
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from backend.core.abstractions import WeatherPoint, WeatherProvider
 
 
@@ -11,4 +13,12 @@ class OpenMeteoProvider(WeatherProvider):
 
     def get_weather(self, latitude: float, longitude: float) -> WeatherPoint:  # noqa: D401
         """Return weather observations from Open-Meteo."""
-        raise NotImplementedError("TODO: integrate with Open-Meteo API")
+        return WeatherPoint(
+            latitude=latitude,
+            longitude=longitude,
+            temperature_c=17.0,
+            pressure_hpa=1008.0,
+            wind_speed_ms=5.0,
+            precipitation_mm=0.1,
+            observed_at=datetime.now(tz=timezone.utc),
+        )

--- a/backend/core/providers/yandex.py
+++ b/backend/core/providers/yandex.py
@@ -1,6 +1,8 @@
 """Yandex weather provider stub."""
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from backend.core.abstractions import WeatherPoint, WeatherProvider
 
 
@@ -11,4 +13,14 @@ class YandexWeatherProvider(WeatherProvider):
 
     def get_weather(self, latitude: float, longitude: float) -> WeatherPoint:  # noqa: D401
         """Return weather observations from Yandex Weather."""
-        raise NotImplementedError("TODO: integrate with Yandex Weather API")
+        # Minimal deterministic payload for local development. Replace with
+        # real API call once the integration is available.
+        return WeatherPoint(
+            latitude=latitude,
+            longitude=longitude,
+            temperature_c=18.5,
+            pressure_hpa=1010.0,
+            wind_speed_ms=4.2,
+            precipitation_mm=0.3,
+            observed_at=datetime.now(tz=timezone.utc),
+        )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,21 @@
 version: "3.9"
 
 services:
+  backend:
+    build:
+      context: .
+      dockerfile: infra/docker/Dockerfile.backend
+    command: ["sh", "-c", "python manage.py migrate --noinput && python manage.py runserver 0.0.0.0:8000"]
+    environment:
+      DJANGO_SECRET_KEY: dev-secret-key
+      DJANGO_DEBUG: "1"
+      DJANGO_ALLOWED_HOSTS: "*"
+      REDIS_URL: redis://redis:6379/0
+    ports:
+      - "8000:8000"
+    depends_on:
+      - redis
+
   mysql:
     image: mysql:8.0
     restart: unless-stopped
@@ -13,6 +28,10 @@ services:
       - "3306:3306"
     volumes:
       - mysql_data:/var/lib/mysql
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
 
   mosquitto:
     image: eclipse-mosquitto:2

--- a/infra/docker/Dockerfile.backend
+++ b/infra/docker/Dockerfile.backend
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY manage.py ./
+COPY backend ./backend
+
+CMD ["sh", "-c", "python manage.py migrate --noinput && python manage.py runserver 0.0.0.0:8000"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+Django>=5.0,<6.0
+djangorestframework>=3.15,<3.16
+django-redis>=5.4,<6.0
 paho-mqtt>=1.6,<2.0
 pydantic>=1.10,<2.0
 SQLAlchemy>=1.4,<3.0


### PR DESCRIPTION
## Summary
- add a dedicated backend service to docker-compose with a slim Python image, Redis cache, and a backend Dockerfile
- implement deterministic Open-Meteo and Yandex providers so the weather endpoint no longer raises stub errors
- include Django/DRF/django-redis dependencies required to run the API inside the container

## Testing
- not run (python package installs blocked by proxy in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959b67b021083338ebb08e9ae888e64)